### PR TITLE
chore(workflows): bump shared-workflows to v1.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   ci:
-    uses: homelabforge/shared-workflows/.github/workflows/python-react-ci.yml@v1.1.0
+    uses: homelabforge/shared-workflows/.github/workflows/python-react-ci.yml@v1.3.0
     with:
       enable-translations: true
       security-tripwire-script: .github/scripts/security-tripwire.sh

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,4 +19,4 @@ permissions:
 
 jobs:
   codeql:
-    uses: homelabforge/shared-workflows/.github/workflows/codeql.yml@v1.1.0
+    uses: homelabforge/shared-workflows/.github/workflows/codeql.yml@v1.3.0

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -9,6 +9,6 @@ permissions:
 
 jobs:
   auto-merge:
-    uses: homelabforge/shared-workflows/.github/workflows/dependabot-auto-merge.yml@v1.1.0
+    uses: homelabforge/shared-workflows/.github/workflows/dependabot-auto-merge.yml@v1.3.0
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   publish:
-    uses: homelabforge/shared-workflows/.github/workflows/python-react-publish.yml@v1.1.0
+    uses: homelabforge/shared-workflows/.github/workflows/python-react-publish.yml@v1.3.0
     with:
       enable-translations: true
       security-tripwire-script: .github/scripts/security-tripwire.sh


### PR DESCRIPTION
## Summary
- Bumps `homelabforge/shared-workflows` from v1.1.0 to v1.3.0 across all 4 workflow files.
- v1.3.0 moves the last 5 node20-runtime actions to node24 majors. Required ahead of the **2026-09-16 Node 20 removal** from GitHub-hosted runners.

## Why now
- 2026-06-02: Node 24 becomes runner default — node20-pinned actions force-bumped (mostly transparent).
- 2026-09-16: Node 20 removed entirely — `runs.using: node20` actions hard-fail.

## What v1.3.0 changed
Pure runtime bumps — no API/input changes for: docker/build-push-action v6→v7.1.0, docker/login-action v3→v4.1.0, docker/setup-buildx-action v3→v4.0.0, softprops/action-gh-release v2→v3.0.0, dependabot/fetch-metadata v2.4.0→v3.1.0. See the [v1.3.0 release notes](https://github.com/homelabforge/shared-workflows/releases/tag/v1.3.0).

## Coordination with v2.27.0-rc2
The active `release/v2.27.0-rc2` branch bumped `ci.yml` to `@v1.2.0` for the new `enable-pg-migrations` input. v1.3.0 includes that input AND the node24 bumps. When rc2 promotes to v2.27.0, rebase against this PR's main (or merge this first and let rc2's diff resolve trivially — both branches will land on @v1.3.0).

## Test plan
- [ ] CI green on this PR
- [ ] Next push to main triggers `ci.yml` cleanly
- [ ] Next tag-triggered release (publish.yml) successfully builds + pushes to GHCR + creates GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)