### PR TITLE
fix(tests): asyncpg loop binding under PG sidecar — closes #77

### DIFF
--- a/backend/app/models/vehicle.py
+++ b/backend/app/models/vehicle.py
@@ -106,8 +106,9 @@ class Vehicle(Base):
     user_id: Mapped[int | None] = mapped_column(
         Integer, ForeignKey("users.id", ondelete="CASCADE"), index=True
     )
-    # Archive fields
-    archived_at: Mapped[datetime | None] = mapped_column(DateTime)
+    # Archive fields. timezone=True because the route code writes
+    # `utc_now()` (TZ-aware); a naive column rejects under PG/asyncpg.
+    archived_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     archive_reason: Mapped[str | None] = mapped_column(
         String(50)
     )  # Sold, Totaled, Gifted, Trade-in, Other

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -15,6 +15,11 @@ pythonpath = .
 # Asyncio mode for async tests
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = session
+# Tests must share the fixture loop, otherwise asyncpg connections that
+# live on the session-scoped engine get awaited from per-test loops and
+# fail with "Future attached to a different loop" / "another operation
+# in progress". See https://github.com/homelabforge/mygarage/issues/77.
+asyncio_default_test_loop_scope = session
 
 # Markers
 markers =

--- a/backend/tests/integration/_cascade.py
+++ b/backend/tests/integration/_cascade.py
@@ -135,15 +135,12 @@ async def assert_cascade_clean(
 
 
 # Sync-engine variant for migration-level cascade tests. Phase 2.5's
-# fuel→odometer cascade verification uses this path because the existing
-# integration-test asyncpg session has a known event-loop issue —
-# tracked at https://github.com/homelabforge/mygarage/issues/77
-# (asyncpg session loop binding under pytest-asyncio's per-test loop
-# scope). Migration tests already run on a sync engine via
-# ``engine_for_migration`` / ``pg_engine``, so calling raw SQL there
-# avoids the asyncpg pain entirely. Once #77 is fixed, the async
-# helper above becomes usable under PG and this sync sibling can stay
-# as the recommended path for migration-level tests.
+# fuel→odometer cascade verification uses this path because migration
+# tests already run on a sync engine via ``engine_for_migration`` /
+# ``pg_engine``. The async helper above is now usable under PG too
+# (issue #77 was fixed by aligning pytest-asyncio's test loop scope
+# with the session-scoped fixture loop) — use the async helper from
+# integration tests, this sync sibling from migration tests.
 
 
 def assert_cascade_clean_sync(

--- a/backend/tests/integration/routes/test_oidc.py
+++ b/backend/tests/integration/routes/test_oidc.py
@@ -304,21 +304,12 @@ class TestOIDCRoutes:
 
     # -------------------------------------------------------------------------
     # /link-account endpoint tests
-    # Note: These tests require the oidc_pending_links table which may not
-    # exist in all test environments. Tests are marked to handle this.
+    # The oidc_pending_links table is always present — created by
+    # Base.metadata.create_all in conftest's init_test_db fixture.
     # -------------------------------------------------------------------------
 
     async def test_link_account_invalid_token(self, client: AsyncClient, db_session):
         """Test link account with invalid token."""
-        from sqlalchemy import text
-
-        # Check if the table exists
-        result = await db_session.execute(
-            text("SELECT name FROM sqlite_master WHERE type='table' AND name='oidc_pending_links'")
-        )
-        if not result.fetchone():
-            pytest.skip("oidc_pending_links table not available in test database")
-
         response = await client.post(
             "/api/auth/oidc/link-account",
             json={
@@ -331,15 +322,6 @@ class TestOIDCRoutes:
 
     async def test_link_account_wrong_password(self, client: AsyncClient, db_session):
         """Test link account with wrong password."""
-        from sqlalchemy import text
-
-        # Check if the table exists
-        result = await db_session.execute(
-            text("SELECT name FROM sqlite_master WHERE type='table' AND name='oidc_pending_links'")
-        )
-        if not result.fetchone():
-            pytest.skip("oidc_pending_links table not available in test database")
-
         response = await client.post(
             "/api/auth/oidc/link-account",
             json={

--- a/backend/tests/integration/routes/test_vehicle.py
+++ b/backend/tests/integration/routes/test_vehicle.py
@@ -72,14 +72,16 @@ class TestVehicleRoutes:
         data = response.json()
         assert data["license_plate"] == "UPDATED-123"
 
-    async def test_delete_vehicle(self, client: AsyncClient, auth_headers, db_session):
+    async def test_delete_vehicle(self, client: AsyncClient, auth_headers, test_user, db_session):
         """Test deleting a vehicle."""
         from app.models.vehicle import Vehicle
 
-        # Create a vehicle specifically for deletion
+        # Create a vehicle specifically for deletion. Pull user_id from
+        # the test_user fixture instead of hardcoding 1 — PG enforces
+        # FKs strictly and the auto-assigned id may not be 1.
         delete_vehicle = Vehicle(
             vin="1HGCM82633A999999",
-            user_id=1,  # test user
+            user_id=test_user["id"],
             nickname="Delete Test Vehicle",
             vehicle_type="Car",
             year=2020,

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,17 +1,17 @@
 # MyGarage backend test stack with a PostgreSQL sidecar.
 #
-# Scope: migration tests (sync engine, asyncpg-free) — the path that
-# would have caught migration 054's PG bugs. Run with:
+# Primary scope: migration tests (sync engine, asyncpg-free) — the
+# path that would have caught migration 054's PG bugs. Run with:
 #
 #   MYGARAGE_TEST_UID=$(id -u) MYGARAGE_TEST_GID=$(id -g) \
 #     docker compose -f docker-compose.test.yml -p mygarage-test \
 #       run --rm mygarage-test pytest tests/migrations/ -v
 #
-# NOT scoped to integration tests (`tests/integration/`) — the async
-# session fixture in backend/tests/conftest.py has an asyncpg loop
-# binding issue under pytest-asyncio's per-test loop scope. Tracked at:
-#   https://github.com/homelabforge/mygarage/issues/77
-# Until #77 lands, integration tests still run on SQLite via bin/ci-check.
+# Integration tests (`tests/integration/`) now run under PG too (issue
+# #77 resolved by aligning pytest-asyncio test loop scope with the
+# session-scoped fixture loop). The CI matrix in shared-workflows
+# still defaults to migration tests only — opt into the integration
+# matrix by passing `pytest tests/integration/` instead.
 
 services:
   postgres-test:


### PR DESCRIPTION
Closes #77.

## Summary
- **Primary fix (commit 8b40137):** one-line addition to pytest.ini so async tests share the loop their session-scoped fixtures live on. Resolves the asyncpg "Future attached to a different loop" / "another operation in progress" errors that gated integration tests from running under the docker-compose.test.yml PG sidecar.
- **Bundled follow-ups (commit 9abdae5):** the three PG-portability fails the primary fix exposed are also addressed here so the integration matrix lands fully green, not 4-from-green.

## Root cause (issue #77)
pytest.ini already had `asyncio_default_fixture_loop_scope = session`, but the *test* default was unset. Under `asyncio_mode = auto` every async test ran in its own per-function loop while reaching into a session-scoped fixture chain (test_engine → test_sessionmaker → db_session). asyncpg connections born on the session loop got awaited from per-test loops and bailed. aiosqlite tolerated the cross-loop awaits, which is why SQLite never noticed.

## Bundled fixes (PG-portability)

1. **`test_oidc.py`** — drop dead `sqlite_master` skip-guards. The two link-account tests guarded themselves with a SQLite-only catalog query that 404s under PG. The guard was dead code anyway — conftest's `init_test_db` runs `Base.metadata.create_all`, which creates `oidc_pending_links` unconditionally.
2. **`Vehicle.archived_at`** → `DateTime(timezone=True)`. The route writes `utc_now()` (TZ-aware) into a TZ-naive column; SQLite tolerates, PG rejects. Narrow model annotation flip; the broader naive→aware sweep stays deferred under its own project. No migration required today (production is SQLite); future PG deployments pick up the right column type via `Base.metadata.create_all`.
3. **`test_delete_vehicle`** — pull `user_id` from the `test_user` fixture instead of hardcoding `1`. PG enforces FKs strictly; SQLite is lax.

## Verification
| Path | Before | After |
|---|---|---|
| `pytest tests/integration/test_cascade_invariants.py` (PG) | hard-fail (loop binding) | **PASS** |
| `pytest tests/integration/` (PG sidecar) | 621 pass / 4 fail | **625 pass / 0 fail** |
| `bin/ci-check --backend` (SQLite) | 1591 pass / 0 fail | **1591 pass / 0 fail** (no regression) |

## Acceptance criteria from #77
- [x] `pytest tests/integration/` passes inside the docker-compose.test.yml PG stack (zero asyncpg loop errors AND zero unrelated portability fails)
- [x] `bin/ci-check --backend` (SQLite path) still passes
- [x] `pg_migration_path_test.py` still passes (migration suite untouched, sync engine path)
- [x] The shared-workflows PG matrix can opt into running integration tests too — change `pg-migrations-pytest-path: tests/migrations/` to `tests/integration/` in the consumer's publish.yml

## Comment cleanup (drive-by)
- `_cascade.py` — drops the "blocked on #77" framing on `assert_cascade_clean_sync`. Both helpers stay (async for integration, sync for migration); neither is blocked anymore.
- `docker-compose.test.yml` — drops the "NOT scoped to integration tests" caveat. CI matrix in shared-workflows still defaults to migrations only; integration matrix is opt-in by changing the `pytest` target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)